### PR TITLE
Fix `system_info` for M1 machines

### DIFF
--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -25,6 +25,11 @@
 namespace osquery {
 namespace tables {
 
+/**
+ * Get a string from a sysctl name.
+ *
+ * @param name sysctl property name
+ */
 std::string getSysctlString(const std::string& name) {
   size_t len = 0;
   std::string ret;
@@ -85,8 +90,8 @@ static inline void genHardwareInfo(Row& r) {
 
   r["hardware_version"] = getIOKitProperty(properties, "version");
   r["hardware_vendor"] = getIOKitProperty(properties, "manufacturer");
-  r["hardware_serial"] = getIOKitProperty(properties, "IOPlatformSerialNumber");
   r["hardware_model"] = getIOKitProperty(properties, "product-name");
+  r["hardware_serial"] = getIOKitProperty(properties, "IOPlatformSerialNumber");
 
   // version, manufacturer, and product-name have a trailing space
   boost::trim(r["hardware_version"]);
@@ -96,11 +101,11 @@ static inline void genHardwareInfo(Row& r) {
 
   CFRelease(properties);
 
-#ifdef __arm__
+#ifdef __aarch64__
   // Mac ARM / M1 machines have the hardware_model one level deeper, in the
   // IODeviceTree:/product key.
   if (r["hardware_model"].empty()) {
-    auto root =
+    root =
         IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/product");
     if (root == MACH_PORT_NULL) {
       VLOG(1) << "Cannot get ARM hardware information from IOKit";


### PR DESCRIPTION
This PR fixes the system_info table for M1 machines, osquery/osquery#7053.

- Switched the `cpu_brand` to query sysctl instead of the IO registry, which appears to be cross platform. This was previously using `cpuid`, which does not exist on ARM.
- Added a check for running on ARM to get the `hardware_model` from the new location on M1, `IODeviceTree:/product`, which is one level deeper than Intel.
- I was unable to find the new location of `hardware_version` that is used on Intel. 

### Sample Output

M1 results:


```
          hostname = m1-mac-mini.local
              uuid = <redacted>
          cpu_type = arm64e
       cpu_subtype = ARM64E
         cpu_brand = Apple M1
cpu_physical_cores = 8
 cpu_logical_cores = 8
     cpu_microcode = 
   physical_memory = 8589934592
   hardware_vendor = Apple Inc.
    hardware_model = Mac mini (M1, 2020)
  hardware_version = 
   hardware_serial = <redacted>
      board_vendor = 
       board_model = 
     board_version = 
      board_serial = 
     computer_name = M1 Mac Mini
    local_hostname = M1-Mac-Mini
```

Intel results:

```
          hostname = adams-mbp
              uuid = <redacted>
          cpu_type = x86_64h
       cpu_subtype = Intel x86-64h Haswell
         cpu_brand = Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
cpu_physical_cores = 4
 cpu_logical_cores = 8
     cpu_microcode = 
   physical_memory = 17179869184
   hardware_vendor = Apple Inc.
    hardware_model = MacBookPro16,2
  hardware_version = 1.0
   hardware_serial = <redacted>
      board_vendor = 
       board_model = 
     board_version = 
      board_serial = 
     computer_name = Adam’s MacBook Pro
    local_hostname = Adams-MacBook-Pro
```

### Validation Tests

- Accurate results for the `system_info` `cpu_brand` and `hardware_model` are returned for both Intel and M1 machines.
- The system_info test passes
  ```
  GTEST_FILTER="SystemInfo.*" ctest -R tests_integration_tables-test -V
  ```